### PR TITLE
clean up JSON schema + tests

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -55,11 +55,11 @@ type ChatCompletionRequest struct {
 	FrequencyPenalty float32                 `json:"frequency_penalty,omitempty"`
 	LogitBias        map[string]int          `json:"logit_bias,omitempty"`
 	User             string                  `json:"user,omitempty"`
-	Functions        []*FunctionDefine       `json:"functions,omitempty"`
+	Functions        []*FunctionDefinition   `json:"functions,omitempty"`
 	FunctionCall     string                  `json:"function_call,omitempty"`
 }
 
-type FunctionDefine struct {
+type FunctionDefinition struct {
 	Name        string `json:"name"`
 	Description string `json:"description,omitempty"`
 	// ParametersRaw is a JSONSchema object describing the function.
@@ -70,8 +70,9 @@ type FunctionDefine struct {
 	Parameters *FunctionParams `json:"-"`
 }
 
-func (fd FunctionDefine) MarshalJSON() ([]byte, error) {
-	type Alias FunctionDefine
+func (fd FunctionDefinition) MarshalJSON() ([]byte, error) {
+	// create alias to avoid recursion
+	type Alias FunctionDefinition
 	var parameters json.RawMessage
 	var err error
 
@@ -93,8 +94,8 @@ func (fd FunctionDefine) MarshalJSON() ([]byte, error) {
 	})
 }
 
-func (fd *FunctionDefine) UnmarshalJSON(data []byte) error {
-	type Alias FunctionDefine
+func (fd *FunctionDefinition) UnmarshalJSON(data []byte) error {
+	type Alias FunctionDefinition
 	aux := &struct {
 		Parameters json.RawMessage `json:"parameters"`
 		*Alias
@@ -121,9 +122,9 @@ func (fd *FunctionDefine) UnmarshalJSON(data []byte) error {
 
 type FunctionParams struct {
 	// the Type must be JSONSchemaTypeObject
-	Type       JSONSchemaType               `json:"type"`
-	Properties map[string]*JSONSchemaDefine `json:"properties,omitempty"`
-	Required   []string                     `json:"required,omitempty"`
+	Type       JSONSchemaType                   `json:"type"`
+	Properties map[string]*JSONSchemaDefinition `json:"properties,omitempty"`
+	Required   []string                         `json:"required,omitempty"`
 }
 
 type JSONSchemaType string
@@ -131,14 +132,15 @@ type JSONSchemaType string
 const (
 	JSONSchemaTypeObject  JSONSchemaType = "object"
 	JSONSchemaTypeNumber  JSONSchemaType = "number"
+	JSONSchemaTypeInteger JSONSchemaType = "integer"
 	JSONSchemaTypeString  JSONSchemaType = "string"
 	JSONSchemaTypeArray   JSONSchemaType = "array"
 	JSONSchemaTypeNull    JSONSchemaType = "null"
 	JSONSchemaTypeBoolean JSONSchemaType = "boolean"
 )
 
-// JSONSchemaDefine is a struct for JSON Schema.
-type JSONSchemaDefine struct {
+// JSONSchemaDefinition is a struct for JSON Schema.
+type JSONSchemaDefinition struct {
 	// Type is a type of JSON Schema.
 	Type JSONSchemaType `json:"type,omitempty"`
 	// Description is a description of JSON Schema.
@@ -146,11 +148,11 @@ type JSONSchemaDefine struct {
 	// Enum is a enum of JSON Schema. It used if Type is JSONSchemaTypeString.
 	Enum []string `json:"enum,omitempty"`
 	// Properties is a properties of JSON Schema. It used if Type is JSONSchemaTypeObject.
-	Properties map[string]*JSONSchemaDefine `json:"properties,omitempty"`
+	Properties map[string]*JSONSchemaDefinition `json:"properties,omitempty"`
 	// Required is a required of JSON Schema. It used if Type is JSONSchemaTypeObject.
 	Required []string `json:"required,omitempty"`
 	// Items is a property of JSON Schema. It used if Type is JSONSchemaTypeArray.
-	Items *JSONSchemaDefine `json:"items,omitempty"`
+	Items *JSONSchemaDefinition `json:"items,omitempty"`
 }
 
 type FinishReason string

--- a/chat_test.go
+++ b/chat_test.go
@@ -75,14 +75,14 @@ func TestChatCompletionsFunctions(t *testing.T) {
 	t.Run("ParametersRaw", func(t *testing.T) {
 		_, err := client.CreateChatCompletion(context.Background(), ChatCompletionRequest{
 			MaxTokens: 5,
-			Model:     GPT3Dot5Turbo,
+			Model:     GPT3Dot5Turbo0613,
 			Messages: []ChatCompletionMessage{
 				{
 					Role:    ChatMessageRoleUser,
 					Content: "Hello!",
 				},
 			},
-			Functions: []*FunctionDefine{{
+			Functions: []*FunctionDefinition{{
 				Name: "test",
 				//nolint:lll
 				ParametersRaw: json.RawMessage(`{"properties":{"count":{"type":"integer","description":"total number of words in sentence"},"words":{"items":{"type":"string"},"type":"array","description":"list of words in sentence"}},"type":"object","required":["count","words"]}`),
@@ -93,31 +93,31 @@ func TestChatCompletionsFunctions(t *testing.T) {
 	t.Run("Parameters", func(t *testing.T) {
 		_, err := client.CreateChatCompletion(context.Background(), ChatCompletionRequest{
 			MaxTokens: 5,
-			Model:     GPT3Dot5Turbo,
+			Model:     GPT3Dot5Turbo0613,
 			Messages: []ChatCompletionMessage{
 				{
 					Role:    ChatMessageRoleUser,
 					Content: "Hello!",
 				},
 			},
-			Functions: []*FunctionDefine{{
+			Functions: []*FunctionDefinition{{
 				Name: "test",
 				Parameters: &FunctionParams{
-					Properties: map[string]*JSONSchemaDefine{
+					Properties: map[string]*JSONSchemaDefinition{
 						"count": {
-							Type:        "integer",
+							Type:        JSONSchemaTypeInteger,
 							Description: "total number of words in sentence",
 						},
 						"words": {
-							Type:        "array",
+							Type:        JSONSchemaTypeArray,
 							Description: "list of words in sentence",
-							Items: &JSONSchemaDefine{
+							Items: &JSONSchemaDefinition{
 								Type: JSONSchemaTypeString,
 							},
 						},
 					},
 					Required: []string{"count", "words"},
-					Type:     "object",
+					Type:     JSONSchemaTypeObject,
 				},
 			}},
 		})
@@ -241,7 +241,7 @@ func getChatCompletionBody(r *http.Request) (ChatCompletionRequest, error) {
 
 func TestMarshalJSON(t *testing.T) {
 	t.Run("ParametersRaw is not nil", func(t *testing.T) {
-		funcDefine := FunctionDefine{Name: "testFunc", ParametersRaw: json.RawMessage(`{"name":"test"}`)}
+		funcDefine := FunctionDefinition{Name: "testFunc", ParametersRaw: json.RawMessage(`{"name":"test"}`)}
 
 		expected := `{"name":"testFunc","parameters":{"name":"test"}}`
 		b, err := funcDefine.MarshalJSON()
@@ -255,9 +255,9 @@ func TestMarshalJSON(t *testing.T) {
 	t.Run("ParametersRaw is nil, Parameters is not nil", func(t *testing.T) {
 		params := &FunctionParams{
 			Type:       JSONSchemaTypeObject,
-			Properties: map[string]*JSONSchemaDefine{"name": {Type: JSONSchemaTypeString}},
+			Properties: map[string]*JSONSchemaDefinition{"name": {Type: JSONSchemaTypeString}},
 		}
-		funcDefine := FunctionDefine{Name: "testFunc", Parameters: params}
+		funcDefine := FunctionDefinition{Name: "testFunc", Parameters: params}
 
 		expected := `{"name":"testFunc","parameters":{"type":"object","properties":{"name":{"type":"string"}}}}`
 		b, err := funcDefine.MarshalJSON()
@@ -271,9 +271,9 @@ func TestMarshalJSON(t *testing.T) {
 	t.Run("ParametersRaw is not nil, Parameters is not nil", func(t *testing.T) {
 		params := &FunctionParams{
 			Type:       JSONSchemaTypeObject,
-			Properties: map[string]*JSONSchemaDefine{"name": {Type: JSONSchemaTypeString}},
+			Properties: map[string]*JSONSchemaDefinition{"name": {Type: JSONSchemaTypeString}},
 		}
-		funcDefine := FunctionDefine{Name: "testFunc", ParametersRaw: json.RawMessage(`{"name":"test"}`), Parameters: params}
+		funcDefine := FunctionDefinition{Name: "testFunc", ParametersRaw: json.RawMessage(`{"name":"test"}`), Parameters: params}
 
 		expected := `{"name":"testFunc","parameters":{"name":"test"}}`
 		b, err := funcDefine.MarshalJSON()
@@ -289,7 +289,7 @@ func TestUnmarshalJSON(t *testing.T) {
 	t.Run("ParametersRaw is valid", func(t *testing.T) {
 		data := []byte(`{"name":"testFunc","parameters":{"type":"object","properties":{"name":{"type":"string"}}}}`)
 
-		var funcDefine FunctionDefine
+		var funcDefine FunctionDefinition
 		err := funcDefine.UnmarshalJSON(data)
 		checks.NoError(t, err)
 
@@ -305,7 +305,7 @@ func TestUnmarshalJSON(t *testing.T) {
 	t.Run("ParametersRaw is invalid", func(t *testing.T) {
 		data := []byte(`{"name":"testFunc","parameters":"invalid json"}`)
 
-		var funcDefine FunctionDefine
+		var funcDefine FunctionDefinition
 		err := funcDefine.UnmarshalJSON(data)
 		checks.HasError(t, err, "invalid character")
 	})


### PR DESCRIPTION
- function calling is only supported with model 0613 or later (updated in tests)
- renamed "define" to "definition" (they are structs not functions, so the names should be nouns and not verbs)
- added JSON schema integer type and updated tests