### PR TITLE
change function call arguments type to json.rawmessage

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -2,6 +2,7 @@ package openai
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 )
@@ -37,7 +38,7 @@ type ChatCompletionMessage struct {
 type FunctionCall struct {
 	Name string `json:"name,omitempty"`
 	// call function with arguments in JSON format
-	Arguments string `json:"arguments,omitempty"`
+	Arguments json.RawMessage `json:"arguments,omitempty"`
 }
 
 // ChatCompletionRequest represents a request structure for chat completion API.

--- a/chat_test.go
+++ b/chat_test.go
@@ -180,7 +180,7 @@ func handleChatCompletionEndpoint(w http.ResponseWriter, r *http.Request) {
 					// this is valid json so it should be fine
 					FunctionCall: &FunctionCall{
 						Name:      completionReq.Functions[0].Name,
-						Arguments: string(fcb),
+						Arguments: fcb,
 					},
 				},
 				Index: i,


### PR DESCRIPTION
When arguments are returned to pass to a function call, keep them as json.RawMessage for ease of use.